### PR TITLE
Use alpine version of golang. Fix typo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ##forked from ianlewis/cloud-dyndns-client
 ##https://github.com/ianlewis/cloud-dyndns-client
-FROM golang:1.13 as build
+FROM golang:alpine as build
 COPY . /src
+RUN apk add git
 RUN cd /src/cmd/cloud-dyndns-client && go build -o /src/cloud-dyndns-client main.go
 FROM alpine:3 as final
 COPY --from=build /src/cloud-dyndns-client /cloud-dyndns-client

--- a/cmd/cloud-dyndns-client/main.go
+++ b/cmd/cloud-dyndns-client/main.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/ianlewis/cloud-dyndns-client/pkg/backend"
 	"github.com/ianlewis/cloud-dyndns-client/pkg/backend/gcp"
-	"github.com/ianlewis/cloud-dyndns-clientpkg/sync"
+	"github.com/ianlewis/cloud-dyndns-client/pkg/sync"
 )
 
 // VERSION is the current version of the application.


### PR DESCRIPTION
It looks like the default "golang" build doesn't use alpine, so the Dockerfile as is generates incompatible binaries. This commit fixes that, and fixes a typo in a import definition.